### PR TITLE
Added pytest to test-requirements.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
 #    update-pep8: {toxinidir}/scripts/update-pep8.sh
 #    unit: nosetests []
 #    functional: {toxinidir}/scripts/kube-init.sh nosetests []
-    modules: pytest ansible/tests --ansible-host-pattern all
+    modules: pytest ansible/tests --ansible-host-pattern all --fixtures ansible/
     format: yapf -i -r openshift/ansible/
     format: yapf -i -r ansible/
 


### PR DESCRIPTION
~~I noticed tests are using ``pytest`` and ``pytest-ansible`` but neither is part of the ``test-requirements.txt``. This change fixes that and removes them from the ``tox`` file.~~ This PR also includes a fix for running the ``tox`` ``modules`` command.